### PR TITLE
Support no_std environments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ quote = "1.0"
 proc-macro2 = "1.0"
 
 [dependencies]
-phf = "0.10"
+phf = { version = "0.10", default-features = false }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,12 @@ categories = ["hardware-support"]
 
 [build-dependencies]
 nom = { version = "6.2", default-features = false }
-phf_codegen = "0.9"
+phf_codegen = "0.10"
 quote = "1.0"
 proc-macro2 = "1.0"
 
 [dependencies]
-phf = "0.9"
+phf = "0.10"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["pci"]
 categories = ["hardware-support"]
 
 [build-dependencies]
-nom = { version = "6.2", default-features = false }
+nom = { version = "7.1", default-features = false }
 phf_codegen = "0.10"
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 //! See the individual documentation for each structure for more details.
 //!
 
+#![no_std]
 #![warn(missing_docs)]
 
 // Codegen: introduces PCI_IDS, a phf::Map<u16, Vendor>.


### PR DESCRIPTION
Hi!

I'd like to depend on this project in [libhermit-rs](https://github.com/hermitcore/libhermit-rs). libhermit-rs is a kernel and can't use `std`. This PR adds support for `no_std` environments (apart from dependency upgrades).

This is working fine for me locally.

What do you think? :)